### PR TITLE
[ENH] PerfectLIF default neuron; improves spike timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .cache
 .coverage
 coverage.xml
+nengo.simulator.logs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Additional extensions for large-scale brain modelling with Nengo.
 
 ### Highlights
- - `nengolib.Network(...)` serves as a drop-in replacement for `nengo.Network(...)` to improve the performance of an ensemble and the accuracy of its decoders.
+ - `nengolib.Network(...)` serves as a drop-in replacement for `nengo.Network(...)` to improve the encoding of an ensemble, the spike timing of each neuron, and the accuracy of the decoders.
  - `nengolib.HeteroSynapse(...)` allows one to connect to an ensemble using a different synapse per dimension or per neuron.
  - `nengolib.LinearFilter(...)` serves as a drop-in replacement for `nengo.LinearFilter(...)` to improve the efficiency of simulations for high-order synapse models.
  - `nengolib.{Lowpass,Alpha,LinearFilter}` are synapses with rich semantics. These linear systems can be scaled, added, multiplied, inverted, compared, and converted between various standard formats. These synapses can also be simulated easily within `Nengo`. For example, to use a double-exponential synapse:
@@ -19,7 +19,7 @@ from nengolib.signal import s
 1 / (tau*s + 1)**2 == nengo.Alpha(tau)  # True
 ```
  - `nengolib.signal.{minreal,balreal,modred}` provide tools for model order reduction of linear systems using minimal and balanced realizations. See `doc/notebooks/research/linear_model_reduction.ipynb` for more information.
- - `nengolib.synapses.ss2sim` can map any `LinearSystem` object to an equivalent system that uses the given synapse. The synapse must be proper, first-order, and causal, and uses a generalization of Principle 3 from he NEF which handles both digital and analog hardware implementations.
+ - `nengolib.synapses.ss2sim` can map any `LinearSystem` object to an equivalent system that uses the given synapse. The synapse must be proper and first-order, and uses a generalization of Principle 3 from he NEF which handles both digital and analog hardware implementations.
 
 ### Installation
 

--- a/nengolib/__init__.py
+++ b/nengolib/__init__.py
@@ -9,6 +9,7 @@ modelling with Nengo.
 from .version import version as __version__  # noqa: F401
 
 from .network import Network  # noqa: F401
+from .neurons import PerfectLIF  # noqa: F401
 
 from . import linalg  # noqa: F401
 from . import signal  # noqa: F401

--- a/nengolib/network.py
+++ b/nengolib/network.py
@@ -1,6 +1,7 @@
 from nengo import Network as BaseNetwork
 from nengo import Ensemble
 
+from nengolib.neurons import PerfectLIF
 from nengolib.stats.ntmdists import ScatteredHypersphere
 
 _all__ = ['Network']
@@ -12,4 +13,5 @@ class Network(BaseNetwork):
         super(Network, self).__init__(*args, **kwargs)
         self.config[Ensemble].update({
             'encoders': ScatteredHypersphere(surface=True),
-            'eval_points': ScatteredHypersphere(surface=False)})
+            'eval_points': ScatteredHypersphere(surface=False),
+            'neuron_type': PerfectLIF()})

--- a/nengolib/neurons.py
+++ b/nengolib/neurons.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from nengo import LIF
+
+
+class PerfectLIF(LIF):
+    """Spiking version of the leaky integrate-and-fire (LIF) neuron model."""
+
+    def step_math(self, dt, J, spiked, voltage, refractory_time):
+        # reduce all refractory times by dt
+        refractory_time -= dt
+
+        # compute effective dt for each neuron, based on remaining time
+        delta_t = (dt - refractory_time).clip(0, dt)
+
+        # update voltage using discretized lowpass filter
+        # since v(dt) = v(0) + (J - v(0))*(1 - exp(-dt/tau)) assuming
+        # J is constant over the interval [t, t + dt)
+        voltage -= (J - voltage) * np.expm1(-delta_t / self.tau_rc)
+
+        # determine which neurons spike (if v > 1 set spiked = 1/dt, else 0)
+        spiked_mask = voltage > 1
+        spiked[:] = spiked_mask / dt
+        spiked_v = voltage[spiked_mask]
+
+        # set v(0) = 1 and solve for dt to compute the spike time
+        t_spike = dt + self.tau_rc * np.log1p(
+            -(spiked_v - 1) / (J[spiked_mask] - 1))
+
+        # set spiked voltages to zero, refractory times to tau_ref, and
+        # rectify negative voltages to a floor of min_voltage
+        voltage[voltage < self.min_voltage] = self.min_voltage
+        voltage[spiked_mask] = 0
+        refractory_time[spiked_mask] = self.tau_ref + t_spike

--- a/nengolib/tests/test_network.py
+++ b/nengolib/tests/test_network.py
@@ -1,7 +1,7 @@
 import nengo
 from nengo import Network as BaseNetwork
 
-from nengolib import Network
+from nengolib import Network, PerfectLIF
 from nengolib.stats import ScatteredHypersphere
 
 
@@ -10,8 +10,10 @@ def test_network():
         x = nengo.Ensemble(100, 1)
         assert isinstance(x.eval_points, ScatteredHypersphere)
         assert isinstance(x.encoders, ScatteredHypersphere)
+        assert isinstance(x.neuron_type, PerfectLIF)
 
     with BaseNetwork():
         x = nengo.Ensemble(100, 1)
         assert not isinstance(x.eval_points, ScatteredHypersphere)
         assert not isinstance(x.encoders, ScatteredHypersphere)
+        assert not isinstance(x.neuron_type, PerfectLIF)

--- a/nengolib/tests/test_neurons.py
+++ b/nengolib/tests/test_neurons.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+import nengo
+from nengo.utils.numpy import rmse
+
+from nengolib import Network, PerfectLIF
+
+
+def _test_lif(Simulator, seed, neuron_type, u, dt=0.001, n=5000,
+              synapse=0.005, t=1.0):
+    with Network(seed=seed) as model:
+        stim = nengo.Node(u)
+        x = nengo.Ensemble(n, 1, neuron_type=neuron_type)
+        nengo.Connection(stim, x, synapse=synapse)
+        p = nengo.Probe(x.neurons)
+
+    sim = Simulator(model, dt=dt)
+    sim.run(t)
+
+    expected = nengo.builder.ensemble.get_activities(sim.model, x, [u])
+    actual = (sim.data[p] > 0).sum(axis=0) / t
+
+    return rmse(actual, expected)
+
+
+def test_perfect_lif(Simulator, seed, logger):
+    for u in np.linspace(-1, 1, 6):
+        error_lif = _test_lif(Simulator, seed, nengo.LIF(), u)
+        error_perfect_lif = _test_lif(Simulator, seed, PerfectLIF(), u)
+        logger.info("%s <? %s (ratio=%s)", error_perfect_lif, error_lif,
+                    error_perfect_lif / error_lif)
+        assert error_perfect_lif < error_lif


### PR DESCRIPTION
This improves the error of the default neuron type in Nengo by as much as 30%, by solving for the exact point within the timestep at which the voltage crosses the threshold (as opposed to being linearly interpolated), and then maintaining the refractory period exactly in a similar manner.

This all works from the assumption that our inputs are piecewise-constant across each `[t, t + dt)` interval. In this case, discretizing the neuron's lowpass filter with time-constant `tau` gives the voltage update:

`v(t) = v(0) + (J - v(0)) * (1 - exp(-dt/tau))`

With this, we can substitute the time leftover from the refractory period into `dt` to account perfectly for the refractory period. In addition, we can set `v(0) = 1` and solve for `dt` to get the time between when the voltage crosses the threshold and the end of the timestep. We then subtract this from `dt` to get the time of the spike:

`dt + tau * ln(1 - (v(t) - 1)/(J - 1))`

Which we then use to update the refractory_period appropriately.