### PR TITLE
[ENH] Improved PadeDelay; renamed to PureDelay

### DIFF
--- a/doc/notebooks/examples/linear_network.ipynb
+++ b/doc/notebooks/examples/linear_network.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "### Delay Example\n",
     "\n",
-    "For example, the `nengolib.synapses.PadeDelay` is a linear system that we can build into a biologically plausible population of neurons to delay an input signal by some fixed amount of time."
+    "For example, the `nengolib.synapses.PureDelay` is a linear system that we can build into a biologically plausible population of neurons to delay an input signal by some fixed amount of time."
    ]
   },
   {
@@ -31,7 +31,7 @@
     "import numpy as np\n",
     "import nengo\n",
     "import nengolib\n",
-    "from nengolib.synapses import PadeDelay\n",
+    "from nengolib.synapses import PureDelay\n",
     "\n",
     "delay = 0.1\n",
     "T = 2.0\n",
@@ -42,7 +42,7 @@
     "    \n",
     "    # Build a LinearNetwork that approximations a delay\n",
     "    subnet = nengolib.networks.LinearNetwork(\n",
-    "        PadeDelay(3, 4, delay), n_neurons=200, synapse=0.02,\n",
+    "        PureDelay(delay, order=4), n_neurons=200, synapse=0.02,\n",
     "        radii=1.5, dt=dt)\n",
     "    nengo.Connection(stim, subnet.input, synapse=None)\n",
     "\n",

--- a/doc/notebooks/research/reservoir_computing.ipynb
+++ b/doc/notebooks/research/reservoir_computing.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "### Structured Reservoirs\n",
     "\n",
-    "We revisit the `PadeDelay` network from `doc/notebooks/examples/linear_network.ipynb`, which approximated a pure delay of $\\tau$ seconds using the transfer function $H(s) = e^{-\\tau s}$. This is implemented below using $1000$ `LIF` neurons and a `Lowpass` synapse. The `radii` were set by inspecting the absolute values of `subnet.x.input` in response to a test stimulus.\n",
+    "We revisit the `PureDelay` network from `doc/notebooks/examples/linear_network.ipynb`, which approximated a pure delay of $\\tau$ seconds using the transfer function $H(s) = e^{-\\tau s}$. This is implemented below using $1000$ `LIF` neurons and a `Lowpass` synapse. The `radii` were set by inspecting the absolute values of `subnet.x.input` in response to a test stimulus.\n",
     "\n",
     "We use this to delay an $8$ Hz band-limited white noise signal by $90$ ms. "
    ]
@@ -51,7 +51,7 @@
    "source": [
     "import nengolib\n",
     "from nengolib.networks import Reservoir, EchoState, LinearNetwork\n",
-    "from nengolib.synapses import PadeDelay, PureDelay\n",
+    "from nengolib.synapses import PureDelay, DiscreteDelay\n",
     "\n",
     "n_neurons = 1000\n",
     "neuron_type = nengo.neurons.LIF()\n",
@@ -59,7 +59,7 @@
     "dt = 0.0005\n",
     "\n",
     "delay = 0.09\n",
-    "function = lambda x: PureDelay(int(delay/dt)).filt(x, dt=dt)\n",
+    "function = lambda x: DiscreteDelay(int(delay/dt)).filt(x, dt=dt)\n",
     "\n",
     "train_t = 2.0\n",
     "test_t = 2.0\n",
@@ -67,7 +67,7 @@
     "\n",
     "with nengolib.Network() as model:\n",
     "    subnet = LinearNetwork(\n",
-    "        PadeDelay(4, 5, delay), n_neurons=n_neurons, synapse=synapse, input_synapse=None,\n",
+    "        PureDelay(delay, order=5), n_neurons=n_neurons, synapse=synapse, input_synapse=None,\n",
     "        radii=[0.1, 0.1, 0.16, 0.21, 0.35], dt=dt, neuron_type=neuron_type, seed=0,\n",
     "        solver=LstsqL2(reg=1e-2))\n",
     "    \n",

--- a/nengolib/networks/tests/test_linear_network.py
+++ b/nengolib/networks/tests/test_linear_network.py
@@ -7,8 +7,8 @@ from nengo.utils.testing import warns
 from nengolib.networks.linear_network import LinearNetwork
 from nengolib import Network
 from nengolib.signal import (
-    apply_filter, impulse, s, Controllable, decompose_states)
-from nengolib.synapses import PadeDelay
+    apply_filter, impulse, s, Controllable, canonical, decompose_states)
+from nengolib.synapses import PureDelay
 
 
 _mock_solver_calls = 0  # global to keep solver's fingerprint static
@@ -95,14 +95,13 @@ def test_expstable():
 
 
 def test_radii(Simulator, seed, plt):
-    sys = PadeDelay(3, 4, 0.1)
+    sys = canonical(PureDelay(0.1, order=4))
     dt = 0.001
     T = 0.3
 
     plt.figure()
 
-    # Precompute the exact bounds for an impulse stimulus (note: this by
-    # default will use the canonical controllable realization).
+    # Precompute the exact bounds for an impulse stimulus
     radii = []
     for sub in decompose_states(sys):
         response = impulse(sub, dt=dt, length=int(T / dt))
@@ -130,7 +129,7 @@ def test_radii(Simulator, seed, plt):
 
     plt.plot(sim.data[p], lw=5, alpha=0.5)
 
-    assert np.allclose(np.max(abs(sim.data[p]), axis=0), 1, atol=1e-4)
+    assert np.allclose(np.max(abs(sim.data[p]), axis=0), 1, atol=1e-3)
 
 
 def test_solver(tmpdir, Simulator, seed, rng):

--- a/nengolib/signal/system.py
+++ b/nengolib/signal/system.py
@@ -46,7 +46,7 @@ def _ss2tf(A, B, C, D):
         D = np.asarray(D).flatten()
         if len(D) != 1:
             raise ValueError("D must be scalar for zero-order models")
-        return (D[0], 1.)
+        return (D[0], 1.)  # pragma: no cover; solved in scipy>=0.18rc2
     nums, den = ss2tf(A, B, C, D)
     if len(nums) != 1:
         # TODO: support MIMO systems

--- a/nengolib/signal/tests/test_lyapunov.py
+++ b/nengolib/signal/tests/test_lyapunov.py
@@ -6,7 +6,7 @@ from nengo.utils.numpy import norm
 from nengolib.signal.lyapunov import (
     _H2P, state_norm, control_gram, observe_gram, l1_norm)
 from nengolib.signal import sys2ss, impulse, cont2discrete, s, z
-from nengolib.synapses import Bandpass, PadeDelay
+from nengolib.synapses import Bandpass, PureDelay
 from nengolib import Lowpass, Alpha
 
 
@@ -80,8 +80,8 @@ def test_l1_norm_known():
 
 
 @pytest.mark.parametrize("sys", [
-    Bandpass(10, 3), Bandpass(50, 50), PadeDelay(3, 4, 0.02),
-    PadeDelay(4, 4, 0.2)])
+    Bandpass(10, 3), Bandpass(50, 50), PureDelay(0.02, 4),
+    PureDelay(0.2, 4, 4)])
 def test_l1_norm_unknown(sys):
     # These impulse responses have zero-crossings which makes computing their
     # exact L1-norm infeasible.

--- a/nengolib/signal/tests/test_normalization.py
+++ b/nengolib/signal/tests/test_normalization.py
@@ -9,7 +9,7 @@ from nengolib import Lowpass, Alpha, Network
 from nengolib.networks import LinearNetwork
 from nengolib.signal import (
     sys_equal, ss_equal, state_norm, impulse, decompose_states)
-from nengolib.synapses import Bandpass, Highpass, PadeDelay
+from nengolib.synapses import Bandpass, Highpass, PureDelay
 
 
 @pytest.mark.parametrize("radius", [0.7, 3, [1.5, 0.2]])
@@ -82,7 +82,7 @@ def _test_normalization(Simulator, sys, rng, normalizer, l1_lower,
 
 @pytest.mark.parametrize("sys", [
     Lowpass(0.005), Alpha(0.01), Bandpass(50, 5), Highpass(0.01, 4),
-    PadeDelay(2, 2, 0.1)])
+    PureDelay(0.1, 2, 2)])
 def test_hankel_normalization(Simulator, sys, rng):
     _test_normalization(Simulator, sys, rng, HankelNorm(),
                         l1_lower=0.3, worst_lower=0.15)
@@ -97,7 +97,7 @@ def test_l1_normalization_positive(Simulator, sys, rng):
 
 
 @pytest.mark.parametrize("sys", [
-    Alpha(0.01), Bandpass(50, 5), Highpass(0.01, 4), PadeDelay(2, 2, 0.1)])
+    Alpha(0.01), Bandpass(50, 5), Highpass(0.01, 4), PureDelay(0.1, 2, 2)])
 def test_l1_normalization_crossing(Simulator, sys, rng):
     _test_normalization(Simulator, sys, rng, L1Norm(),
                         l1_lower=0.9, worst_lower=0.2)

--- a/nengolib/signal/tests/test_reduction.py
+++ b/nengolib/signal/tests/test_reduction.py
@@ -9,11 +9,11 @@ from nengolib.signal.reduction import (
 from nengolib import Lowpass, Alpha
 from nengolib.signal import (
     sys2ss, sys_equal, LinearSystem, apply_filter, control_gram, observe_gram)
-from nengolib.synapses import PadeDelay
+from nengolib.synapses import PureDelay
 
 
 @pytest.mark.parametrize("sys", [
-    PadeDelay(3, 4, 0.1), PadeDelay(5, 5, 0.2), Alpha(0.2)])
+    PureDelay(0.1, 4), PureDelay(0.2, 5, 5), Alpha(0.2)])
 def test_hankel(sys):
     assert np.allclose(hankel(sys), balreal(sys)[1])
 

--- a/nengolib/signal/tests/test_system.py
+++ b/nengolib/signal/tests/test_system.py
@@ -9,7 +9,7 @@ from nengolib.signal.system import (
     sys2ss, sys2zpk, sys2tf, canonical, sys_equal, ss_equal, is_exp_stable,
     decompose_states, LinearSystem, s, z)
 from nengolib import Network, Lowpass, Alpha, LinearFilter
-from nengolib.synapses import PadeDelay
+from nengolib.synapses import PureDelay
 
 
 def test_sys_conversions():
@@ -17,15 +17,16 @@ def test_sys_conversions():
 
     tf = sys2tf(sys)
     ss = sys2ss(sys)
+    zpk = sys2zpk(sys)
 
     assert sys_equal(sys2ss(tf), ss)
     assert sys_equal(sys2ss(ss), ss)  # unchanged
     assert sys_equal(sys2tf(tf), tf)  # unchanged
     assert sys_equal(sys2tf(ss), tf)
 
-    zpk = sys2zpk(ss)
     assert sys_equal(sys2zpk(zpk), zpk)  # sanity check
     assert sys_equal(sys2zpk(tf), zpk)  # sanity check
+    assert sys_equal(sys2zpk(ss), zpk)
     assert sys_equal(sys2tf(zpk), tf)
     assert sys_equal(sys2ss(zpk), ss)
 
@@ -36,7 +37,8 @@ def test_sys_conversions():
 
     # system can also be just a scalar
     assert sys_equal(sys2tf(2.0), (1, 0.5))
-    assert sys_equal(sys2tf(sys2ss(5)), (5, 1))
+    assert np.allclose(sys2ss(5)[3], 5)
+    assert sys_equal(sys2zpk(5), 5)
 
     with pytest.raises(ValueError):
         sys2ss(np.zeros(5))
@@ -110,7 +112,7 @@ def test_is_exp_stable():
     assert not is_exp_stable(sys)
 
 
-@pytest.mark.parametrize("sys", [PadeDelay(3, 4, 0.1), PadeDelay(5, 5, 0.2)])
+@pytest.mark.parametrize("sys", [PureDelay(0.1, 4), PureDelay(0.2, 5, 5)])
 def test_decompose_states(sys):
     assert np.dot(sys.C, decompose_states(sys)) + sys.D == sys
 

--- a/nengolib/synapses/digital.py
+++ b/nengolib/synapses/digital.py
@@ -4,10 +4,10 @@ from nengo.utils.compat import is_integer
 
 from nengolib.signal.system import z
 
-__all__ = ['PureDelay', 'BoxFilter']
+__all__ = ['DiscreteDelay', 'BoxFilter']
 
 
-def PureDelay(steps):
+def DiscreteDelay(steps):
     """Delays its input signal by a fixed number of timesteps."""
     if not is_integer(steps) or steps < 0:
         raise ValueError("steps (%s) must be non-negative integer" % (steps,))
@@ -16,7 +16,7 @@ def PureDelay(steps):
 
 def BoxFilter(width, normalized=True):
     """Sums over width + 1 timesteps."""
-    den = PureDelay(width)
+    den = DiscreteDelay(width)
     amplitude = 1.0 / (width + 1) if normalized else 1.0
     # 1 + 1/z + ... + 1/z^(steps) = (z^steps + z^(steps-1) + ... + 1)/z^steps
     return amplitude * sum(z**k for k in range(width+1)) * den

--- a/nengolib/synapses/tests/test_digital.py
+++ b/nengolib/synapses/tests/test_digital.py
@@ -1,14 +1,14 @@
 import numpy as np
 import pytest
 
-from nengolib.synapses.digital import PureDelay, BoxFilter
+from nengolib.synapses.digital import DiscreteDelay, BoxFilter
 from nengolib.signal import impulse, z, minreal
 
 
 @pytest.mark.parametrize("steps", [0, 1, 5])
 def test_pure_delay(steps):
     length = 20
-    sys = PureDelay(steps)
+    sys = DiscreteDelay(steps)
     y = impulse(sys, dt=None, length=length)
     assert np.allclose(y, [0]*steps + [1] + [0]*(length - steps - 1))
 
@@ -28,10 +28,10 @@ def test_box_filter(width, normalized):
 
 def test_bad_steps():
     with pytest.raises(ValueError):
-        PureDelay(-1)
+        DiscreteDelay(-1)
 
     with pytest.raises(ValueError):
-        PureDelay(1.5)
+        DiscreteDelay(1.5)
 
     with pytest.raises(ValueError):
         BoxFilter(-1)
@@ -41,8 +41,8 @@ def test_bad_steps():
 
 
 def test_equivalent_defs():
-    assert PureDelay(5) == (~z)**5
-    assert PureDelay(5) == 1 / z**5
+    assert DiscreteDelay(5) == (~z)**5
+    assert DiscreteDelay(5) == 1 / z**5
 
     # equivalent to an (undelayed) integrator convolved with a delayed cutoff
     assert BoxFilter(5, normalized=False) == minreal(


### PR DESCRIPTION
Redid the derivation from `n = p = q` for `p = q - 1` to get more stable numerics for the most common case.