### PR TITLE
[FIX] Default normalizer copies radii

### DIFF
--- a/nengolib/signal/normalization.py
+++ b/nengolib/signal/normalization.py
@@ -66,7 +66,8 @@ class AbstractScaleState(AbstractNormalizer):
 
     def __call__(self, sys, radii=1.0):
         sys = LinearSystem(sys)
-        radii *= np.asarray(self.radii(sys))
+        # Note: don't mutate the user's radii
+        radii = radii * np.asarray(self.radii(sys))
         return scale_state(sys, radii=radii), {'radii': radii}
 
     def radii(self, sys):

--- a/nengolib/signal/tests/test_normalization.py
+++ b/nengolib/signal/tests/test_normalization.py
@@ -48,6 +48,13 @@ def test_ccf_normalization():
         ([[-15, 2], [-25, 0]], [[0], [25]], [[1, 0]], [[0]]))
 
 
+def test_radii_immutability():
+    radii = np.asarray([1, 2])
+    radii.flags.writeable = False
+    HankelNorm()(Alpha(0.1), radii=radii)
+    assert np.allclose(radii, [1, 2])  # issues/90
+
+
 @pytest.mark.parametrize("sys", [PureDelay(0.1, 4), PureDelay(0.05, 5, 5)])
 def test_balreal_normalization(sys):
     normalized, info = Balreal()(sys)


### PR DESCRIPTION
Resolves #90. Confirmed that this new test fails on current `master`.