### PR TITLE
[FIX] Bug in general synapse mapping

### DIFF
--- a/nengolib/synapses/mapping.py
+++ b/nengolib/synapses/mapping.py
@@ -39,7 +39,7 @@ def ss2sim(sys, synapse, dt=None):
     c = synapse.den / gain
 
     A, B, C, D = sys.ss
-    k = len(sys)
+    k = len(synapse)
     powA = [matrix_power(A, i) for i in range(k + 1)]
     AH = np.sum([c[i] * powA[i] for i in range(k + 1)], axis=0)
 

--- a/nengolib/synapses/tests/test_mapping.py
+++ b/nengolib/synapses/tests/test_mapping.py
@@ -103,9 +103,8 @@ def test_principle3_discrete():
         ss2sim(sys, cont2discrete(syn, dt=dt), dt=None), FH)
 
 
-def test_doubleexp_continuous():
-    sys = PureDelay(0.1, order=5)
-
+@pytest.mark.parametrize("sys", [PureDelay(0.1, order=5), Lowpass(0.1)])
+def test_doubleexp_continuous(sys):
     tau1 = 0.05
     tau2 = 0.02
     syn = DoubleExp(tau1, tau2)


### PR DESCRIPTION
This was a pretty serious bug, since it meant the mapping wasn't being exploited to full effect. Fortunately this could only be seen when `len(sys) < len(synapse)`, since otherwise accessing elements out of bounds in a numpy polynomial returns 0 by default (which was good).