### PR TITLE
Fix biased solver bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
         NENGO=""
         PIP_DEPS="$PIP_DEPS nengo==2.3.0"
     - env:
+        PYTHON="2.7"
+        NENGO=""
+        PIP_DEPS="$PIP_DEPS nengo==2.4.0"
+    - env:
         CODE_COV="True"
         TEST_CMD="py.test nengolib --cov=nengolib"
         PYTHON="2.7"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Simply add the line **`import nengolib; nengolib.patch()`** to the top of your c
 
 ### Installation
 
-NengoLib is tested rigorously (100% coverage) against Python 2.7, 3.4, and 3.5, and [Nengo](https://github.com/nengo/nengo/releases) 2.1.0, 2.1.2, 2.2.0, 2.3.0, and its development branch.
+NengoLib is tested rigorously (100% coverage) against Python 2.7, 3.4, and 3.5, and [Nengo](https://github.com/nengo/nengo/releases) 2.1.0, 2.1.2, 2.2.0, 2.3.0, 2.4.0, and its development branch. The Nengo GUI is not officially supported.
 
 To install the development version of NengoLib:
 ```

--- a/doc/notebooks/examples/linear_network.ipynb
+++ b/doc/notebooks/examples/linear_network.ipynb
@@ -42,7 +42,7 @@
     "    \n",
     "    # Build a LinearNetwork that approximations a delay\n",
     "    subnet = nengolib.networks.LinearNetwork(\n",
-    "        PureDelay(delay, order=4), n_neurons=200, synapse=0.02,\n",
+    "        PureDelay(delay, order=4), n_neurons_per_ensemble=200, synapse=0.02,\n",
     "        radii=1.0, dt=dt, output_synapse=0.02)\n",
     "    nengo.Connection(stim, subnet.input, synapse=None)\n",
     "\n",
@@ -163,7 +163,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.3"
   }
  },
  "nbformat": 4,

--- a/doc/notebooks/research/discrete_comparison.ipynb
+++ b/doc/notebooks/research/discrete_comparison.ipynb
@@ -43,7 +43,7 @@
     "    with nengolib.Network(seed=seed) as model:\n",
     "        stim = nengo.Node(output=nengo.processes.WhiteSignal(T, high=50, rms=0.1, y0=0))\n",
     "        subnet = nengolib.networks.LinearNetwork(\n",
-    "            sys, n_neurons=n_neurons, synapse=synapse,\n",
+    "            sys, n_neurons_per_ensemble=n_neurons, synapse=synapse,\n",
     "            radii=1.0, dt=dt if discretized else None, output_synapse=synapse,\n",
     "            neuron_type=neuron_type)\n",
     "        nengo.Connection(stim, subnet.input, synapse=None)\n",
@@ -105,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.3"
   }
  },
  "nbformat": 4,

--- a/doc/notebooks/research/reservoir_computing.ipynb
+++ b/doc/notebooks/research/reservoir_computing.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "with nengolib.Network() as model:\n",
     "    subnet = LinearNetwork(\n",
-    "        PureDelay(delay, order=5), n_neurons=n_neurons, synapse=synapse,\n",
+    "        PureDelay(delay, order=5), n_neurons_per_ensemble=n_neurons, synapse=synapse,\n",
     "        radii=[0.1, 0.1, 0.16, 0.21, 0.35], dt=dt, neuron_type=neuron_type, seed=0,\n",
     "        solver=LstsqL2(reg=1e-2))\n",
     "    \n",

--- a/nengolib/connection.py
+++ b/nengolib/connection.py
@@ -11,12 +11,11 @@ __all__ = ['Connection']
 class Connection(BaseConnection):
     """Extends nengo.Connection to improve decoding with a bias."""
 
-    def __init__(self, pre, post, solver=LstsqL2(), bias_magnitude=1.0,
-                 **kwargs):
+    def __init__(self, pre, post, solver=LstsqL2(), **kwargs):
         if isinstance(pre, nengo.Ensemble):
-            solver = BiasedSolver(solver, magnitude=bias_magnitude)
+            solver = BiasedSolver(solver)
             nengo.Connection(
-                nengo.Node(output=bias_magnitude, label="Bias"), post,
+                nengo.Node(output=0, label="Bias"), post,
                 function=solver.bias_function(post.size_in), synapse=None)
 
         super(Connection, self).__init__(pre, post, solver=solver, **kwargs)

--- a/nengolib/networks/linear_network.py
+++ b/nengolib/networks/linear_network.py
@@ -24,7 +24,7 @@ class LinearNetwork(Network):
     output_synapse = SynapseParam('input_synapse', optional=True)
     dt = NumberParam('dt', low=0, low_open=True, optional=True)
 
-    def __init__(self, sys, n_neurons, synapse, dt, radii=1.0,
+    def __init__(self, sys, n_neurons_per_ensemble, synapse, dt, radii=1.0,
                  input_synapse=None, output_synapse=None,
                  normalizer=default_normalizer(), solver=Default,
                  label=None, seed=None, add_to_container=None, **ens_kwargs):
@@ -32,7 +32,7 @@ class LinearNetwork(Network):
 
         # Parameter checking
         self.sys = LinearSystem(sys)
-        self.n_neurons = n_neurons
+        self.n_neurons_per_ensemble = n_neurons_per_ensemble
         self.synapse = synapse
         self.dt = dt
         self.radii = radii
@@ -69,8 +69,8 @@ class LinearNetwork(Network):
             self.input = nengo.Node(size_in=self.size_in, label="input")
             self.output = nengo.Node(size_in=self.size_out, label="output")
             self.x = nengo.networks.EnsembleArray(
-                self.n_neurons, self.size_state, ens_dimensions=1,
-                **ens_kwargs)
+                self.n_neurons_per_ensemble, self.size_state,
+                ens_dimensions=1, **ens_kwargs)
 
             if solver is not Default:
                 # https://github.com/nengo/nengo/issues/1044

--- a/nengolib/networks/tests/test_linear_network.py
+++ b/nengolib/networks/tests/test_linear_network.py
@@ -39,8 +39,8 @@ def test_linear_network(neuron_type, atol, Simulator, plt, seed, rng):
         stim = nengo.Node(
             output=nengo.processes.WhiteSignal(T, high=10, seed=seed))
         subnet = LinearNetwork(
-            sys, n_neurons, synapse=synapse, input_synapse=synapse, dt=dt,
-            neuron_type=neuron_type)
+            sys, n_neurons_per_ensemble=n_neurons, synapse=synapse,
+            input_synapse=synapse, dt=dt, neuron_type=neuron_type)
         nengo.Connection(
             stim, subnet.input, synapse=None, transform=scale_input)
 
@@ -189,7 +189,7 @@ def test_radii(Simulator, seed, plt):
         stim = nengo.Node(output=lambda t: 1 / dt if t <= dt else 0)
 
         # Set explicit radii for controllable realization
-        subnet = LinearNetwork(sys, n_neurons=1, synapse=0.2,
+        subnet = LinearNetwork(sys, n_neurons_per_ensemble=1, synapse=0.2,
                                input_synapse=0.2, dt=dt,
                                radii=radii, normalizer=Controllable(),
                                neuron_type=nengo.neurons.Direct())

--- a/nengolib/signal/tests/test_normalization.py
+++ b/nengolib/signal/tests/test_normalization.py
@@ -75,8 +75,8 @@ def _test_normalization(Simulator, sys, rng, normalizer, l1_lower,
         stim = nengo.Node(output=lambda t: rng.choice([-radius, radius])
                           if t < T/2 else radius)
         tau = 0.02
-        subnet = LinearNetwork(sys, n_neurons=1, synapse=tau, dt=dt,
-                               input_synapse=tau,
+        subnet = LinearNetwork(sys, n_neurons_per_ensemble=1, synapse=tau,
+                               dt=dt, input_synapse=tau,
                                radii=radius, normalizer=normalizer,
                                neuron_type=nengo.neurons.Direct())
         nengo.Connection(stim, subnet.input, synapse=None)

--- a/nengolib/tests/test_solvers.py
+++ b/nengolib/tests/test_solvers.py
@@ -3,7 +3,6 @@ import pytest
 import numpy as np
 
 import nengo
-from nengo.exceptions import NengoException
 
 from nengolib.solvers import BiasedSolver
 from nengolib import Network
@@ -41,14 +40,3 @@ def test_biased_solver_weights(Simulator):
         nengo.Connection(x, x, solver=solver)
 
     Simulator(model)
-
-
-def test_biased_improper_usage(Simulator):
-    solver = BiasedSolver()
-    with Network() as model:
-        x = nengo.Ensemble(100, 1)
-        nengo.Connection(x, x, solver=solver)
-        nengo.Connection(x, x, solver=solver)
-
-    with pytest.raises(NengoException):  # can't use same solver twice
-        Simulator(model)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 exclude = _*.py
 
-[pytest]
+[tool:pytest]
 addopts = -p nengo.tests.options
 norecursedirs = .* build doc *.logs


### PR DESCRIPTION
Resolves #60.

Removing the `bias_magnitude` parameter makes the code more understandable and less error-prone. Its effect on regularization is also not well understood (i.e., setting it greater than 1 would cause `A.max()` to increase).

Also had to change the `n_neurons` attribute on `LinearNetwork` to sync up with Nengo 2.4.0. This breaks compatibility with https://github.com/arvoelke/delay2017