### PR TITLE
Improve PyPi release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 Release History
 ***************
 
-0.4.2 (unreleased)
-==================
+0.4.2 (May 18, 2018)
+====================
 
 Tested against Nengo versions 2.1.0-2.7.0.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,7 @@ prune dist
 # Patterns to exclude from any directory
 global-exclude *.git*
 global-exclude *-checkpoint.ipynb
+global-exclude *.swp
 
 # Exclude all bytecode
 global-exclude *.pyc *.pyo *.pyd

--- a/nengolib/version.py
+++ b/nengolib/version.py
@@ -1,6 +1,6 @@
 """Nengo Library version information."""
 
 version_info = (0, 4, 2)  # (major, minor, patch)
-release_type = "-dev"
+release_type = ""
 
 version = "%s%s" % (".".join(map(str, version_info)), release_type)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 description-file = README.rst
 
+[bdist_wheel]
+universal = 1
+
 [flake8]
 exclude = _*.py,docs/*.py,build/*.py
 ignore = E226,E741

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python
 
 import imp
+import io
 import os
 from setuptools import setup, find_packages
+
+
+def read(*filenames, **kwargs):
+    encoding = kwargs.get("encoding", "utf-8")
+    sep = kwargs.get("sep", "\n")
+    buf = []
+    for filename in filenames:
+        with io.open(filename, encoding=encoding) as f:
+            buf.append(f.read())
+    return sep.join(buf)
 
 name = 'nengolib'
 root = os.path.dirname(os.path.realpath(__file__))
@@ -25,6 +36,7 @@ setup(
     author="Aaron R. Voelker",
     author_email="arvoelke@gmail.com",
     description="Tools for robust dynamics in Nengo",
+    long_description=read("README.rst", "CHANGES.rst"),
     url="https://github.com/arvoelke/nengolib/",
     download_url=download_url,
     license="Free for non-commercial use (see Nengo license)",


### PR DESCRIPTION
Released 0.4.1 using the new recommended tool chain, via:
```
python setup.py sdist bdist_wheel
twine upload dist/*
```

However...
 - [ ] Release no longer includes README? https://pypi.python.org/pypi/nengolib/0.4.1 -- Why is it missing? How to put it back?
 - [ ] Wheel should be marked as compatible with Python 2 as well. Did this commit fix it?