### PR TITLE
Quasi Monte Carlo Rd Sampling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ matrix:
         NENGO=""
         PIP_DEPS="$PIP_DEPS nengo==2.7.0"
     - env:
+        PYTHON="2.7"
+        NENGO=""
+        PIP_DEPS="$PIP_DEPS nengo==2.8.0"
+    - env:
         CODE_COV="True"
         TEST_CMD="py.test nengolib --cov=nengolib"
         PYTHON="2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         SCIPY=""
         NENGO=""
     - env:
-        TEST_CMD="py.test nengolib -k nengolib/tests/test_notebooks.py -rw --slow"
+        TEST_CMD="py.test nengolib/tests/test_notebooks.py --slow"
         PYTHON="2.7"
         CONDA_DEPS="matplotlib jupyter ipython pygments"
     - env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ Release History
   See ``notebooks/examples/full_force_learning.ipynb`` for an
   example that uses this to implement spiking FORCE in Nengo.
   (`#133 <https://github.com/arvoelke/nengolib/pull/133>`_)
+- Added the ``nengolib.stats.Rd()`` method for quasi-random sampling of
+  arbitrarily high-dimensional vectors. It is now the default method for
+  scattered sampling of encoders and evaluation points.
+  The method can be manually switched back to ``nengolib.stats.Sobol()``.
+  (`#153 <https://github.com/arvoelke/nengolib/pull/153>`_)
 
 0.4.2 (May 18, 2018)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Release History
 0.4.3 (unreleased)
 ==================
 
+Tested against Nengo versions 2.1.0-2.8.0.
+
 **Added**
 
 - Added the ``nengolib.RLS()`` recursive least-squares (RLS)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,8 +19,8 @@ Installation
 
 `Nengolib <https://github.com/arvoelke/nengolib/>`_
 is tested against Python 2.7, 3.4, 3.5, and 3.6, and `Nengo`_
-2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, and 2.7.0.
-We recommend ``nengo==2.7.0`` for complete access to features.
+2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2,7.0, and 2.8.0.
+We recommend ``nengo==2.8.0`` for complete access to features.
 The `Nengo GUI <https://github.com/nengo/nengo_gui>`_ is not officially
 supported.
 To install::

--- a/docs/nengolib.stats.Rd.rst
+++ b/docs/nengolib.stats.Rd.rst
@@ -1,0 +1,6 @@
+nengolib\.stats\.Rd
+===================
+
+.. currentmodule:: nengolib.stats
+
+.. autoclass:: Rd

--- a/docs/notebooks/examples/full_force_learning.ipynb
+++ b/docs/notebooks/examples/full_force_learning.ipynb
@@ -284,21 +284,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/examples/hetero_synapse.ipynb
+++ b/docs/notebooks/examples/hetero_synapse.ipynb
@@ -271,9 +271,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -289,5 +289,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/notebooks/examples/network.ipynb
+++ b/docs/notebooks/examples/network.ipynb
@@ -61,23 +61,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/notebooks/examples/rolling_window.ipynb
+++ b/docs/notebooks/examples/rolling_window.ipynb
@@ -336,9 +336,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "\n",
     "\n"
@@ -347,23 +345,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/notebooks/research/discrete_comparison.ipynb
+++ b/docs/notebooks/research/discrete_comparison.ipynb
@@ -85,23 +85,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/notebooks/research/geometric_decoders.ipynb
+++ b/docs/notebooks/research/geometric_decoders.ipynb
@@ -386,23 +386,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/notebooks/research/linear_model_reduction.ipynb
+++ b/docs/notebooks/research/linear_model_reduction.ipynb
@@ -339,23 +339,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/docs/notebooks/research/sampling_high_dimensional_vectors.ipynb
+++ b/docs/notebooks/research/sampling_high_dimensional_vectors.ipynb
@@ -28,8 +28,10 @@
     "\n",
     "uniform_ball = nengo.dists.UniformHypersphere(surface=False)\n",
     "uniform_sphere = nengo.dists.UniformHypersphere(surface=True)\n",
-    "scatter_ball = ScatteredHypersphere(surface=False)\n",
-    "scatter_sphere = ScatteredHypersphere(surface=True)"
+    "\n",
+    "# base=Rd() is now the default\n",
+    "scatter_ball = ScatteredHypersphere(surface=False, base=Sobol())\n",
+    "scatter_sphere = ScatteredHypersphere(surface=True, base=Sobol())"
    ]
   },
   {
@@ -207,7 +209,7 @@
     " - ~~Poisson Disk~~\n",
     " - Sobol\n",
     " \n",
-    "Since **Sobol** had the most readily-available Python library (and the largest Wikipedia page), I used it for all my experiments.\n",
+    "Since **Sobol** had the most readily-available Python library (and the largest Wikipedia page), I used it for all my experiments. The default method has been updated to **[Rd](http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/)** since the writing of this notebook.\n",
     "\n",
     "All of these approaches (except the Latin Square and Poisson Disk sampling) attempt to minimize the **discrepancy** of the samples. Informally, the discrepancy measure tells us how much the sample distribution differs from the underlying distribution. Formally, we define the empirical distribution as the cumulative distribution function (CDF) $F_N({\\bf x}) = P({\\bf X} \\le {\\bf x})$, where:\n",
     "\n",
@@ -353,14 +355,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/research/sampling_high_dimensional_vectors.ipynb
+++ b/docs/notebooks/research/sampling_high_dimensional_vectors.ipynb
@@ -348,9 +348,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -362,9 +362,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/nengolib/stats/__init__.py
+++ b/nengolib/stats/__init__.py
@@ -23,6 +23,7 @@ Distributions
    SphericalCoords
    ScatteredCube
    Sobol
+   Rd
 
 Sphere-packing
 --------------


### PR DESCRIPTION
Resolves #152. Code is modified from http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/

This is a new method for sampling points from the sphere and ball (encoders and evaluation points). 
It is still possible to use the old method by passing **`base=Sobol()`** to the constructor of all of the distributions, instead of the new default of **`base=Rd()`**. The biggest benefit is the new method works for arbitrary dimension, whereas the old method regressed to Nengo's independent distribution for `d > 40`.

Some plots from the **new** method (to be in the documentation upon release):

![new_documentation](https://user-images.githubusercontent.com/5420057/44881168-ab05b400-ac7c-11e8-8864-0f22477f7bb6.png)

![new_documentation2](https://user-images.githubusercontent.com/5420057/44881167-ab05b400-ac7c-11e8-9268-fe7df788c3f5.png)

![new_documentation3](https://user-images.githubusercontent.com/5420057/44881166-ab05b400-ac7c-11e8-8a0e-675630d0aff8.png)

Versus the **old** method (Sobol):

![old_documentation1](https://user-images.githubusercontent.com/5420057/44881277-12236880-ac7d-11e8-9f4e-b9cdab1e2826.png)

![old_documentation2](https://user-images.githubusercontent.com/5420057/44881276-12236880-ac7d-11e8-9113-17bb81c0b805.png)

![old_documentation3](https://user-images.githubusercontent.com/5420057/44881278-12236880-ac7d-11e8-9909-736f26120780.png)