### PR TITLE
Helper function to initialize LIF state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ notifications:
 env:
   global:
     - TEST_CMD="py.test nengolib"
-    - PIP_DEPS="pytest"
     - NUMPY="1.10"
     - SCIPY="0.17.0"
+    - PIP_DEPS=""
     - NENGO="https://github.com/nengo/nengo/archive/master.tar.gz"
     - CONDA_DEPS="matplotlib"
 
@@ -18,46 +18,45 @@ matrix:
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.1.0"
+        PIP_DEPS="nengo==2.1.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.2.0"
+        PIP_DEPS="nengo==2.2.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.3.0"
+        PIP_DEPS="nengo==2.3.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.4.0"
+        PIP_DEPS="nengo==2.4.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.5.0"
+        PIP_DEPS="nengo==2.5.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.6.0"
+        PIP_DEPS="nengo==2.6.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.7.0"
+        PIP_DEPS="nengo==2.7.0 pytest==3.2"
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="$PIP_DEPS nengo==2.8.0"
+        PIP_DEPS="nengo==2.8.0 pytest==3.2"
     - env:
         CODE_COV="True"
         TEST_CMD="py.test nengolib --cov=nengolib"
         PYTHON="2.7"
-        PIP_DEPS="$PIP_DEPS codecov pytest-cov"
+        PIP_DEPS="codecov pytest pytest-cov"
     - env: >
         EXTRA_CMD="flake8 -v nengolib"
         CONDA_DEPS="flake8"
         PYTHON="2.7"
         TEST_CMD=""
-        PIP_DEPS=""
         NUMPY=""
         SCIPY=""
         NENGO=""
@@ -65,16 +64,20 @@ matrix:
         TEST_CMD="py.test nengolib/tests/test_notebooks.py --slow"
         PYTHON="2.7"
         CONDA_DEPS="matplotlib jupyter ipython pygments"
+        PIP_DEPS="pytest"
     - env:
         PYTHON="3.4"
+        PIP_DEPS="pytest"
     - env:
         PYTHON="3.5"
         NUMPY="1.12.0"
         SCIPY="0.19.0"
+        PIP_DEPS="pytest"
     - env:
         PYTHON="3.6"
         NUMPY="1.13.3"
         SCIPY="1.0.0"
+        PIP_DEPS="pytest"
 
 # Setup Miniconda
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ notifications:
 env:
   global:
     - TEST_CMD="py.test nengolib"
-    - NUMPY="1.10"
-    - SCIPY="0.17.0"
+    - NUMPY="1.13"
+    - SCIPY="0.19.0"
     - PIP_DEPS=""
     - NENGO="https://github.com/nengo/nengo/archive/master.tar.gz"
     - CONDA_DEPS="matplotlib"
@@ -67,15 +67,14 @@ matrix:
         PIP_DEPS="pytest"
     - env:
         PYTHON="3.4"
-        PIP_DEPS="pytest"
+        PIP_DEPS="pytest numpy==1.13.0 scipy==0.19.0"
+        NUMPY=""
+        SCIPY=""
     - env:
         PYTHON="3.5"
-        NUMPY="1.12.0"
-        SCIPY="0.19.0"
         PIP_DEPS="pytest"
     - env:
         PYTHON="3.6"
-        NUMPY="1.13.3"
         SCIPY="1.0.0"
         PIP_DEPS="pytest"
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ We now require ``numpy>=1.13.0`` and ``scipy>=0.19.0``.
   scattered sampling of encoders and evaluation points.
   The method can be manually switched back to ``nengolib.stats.Sobol()``.
   (`#153 <https://github.com/arvoelke/nengolib/pull/153>`_)
+- Added the ``nengolib.neuron.init_lif(sim, ens)`` helper function
+  for initializing the neural state of a ``LIF`` ensemble, from within
+  a simulator block, to represent ``0`` uniformly at the start.
+  (`#156 <https://github.com/arvoelke/nengolib/pull/156>`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Release History
 ==================
 
 Tested against Nengo versions 2.1.0-2.8.0.
+We now require ``numpy>=1.13.0`` and ``scipy>=0.19.0``.
 
 **Added**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Tested against Nengo versions 2.1.0-2.8.0.
   The method can be manually switched back to ``nengolib.stats.Sobol()``.
   (`#153 <https://github.com/arvoelke/nengolib/pull/153>`_)
 
+**Fixed**
+
+- Release no longer requires ``pytest``.
+  (`#156 <https://github.com/arvoelke/nengolib/pull/156>`_)
+
 0.4.2 (May 18, 2018)
 ====================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,8 +29,8 @@ To install::
 
 This requires
 `nengo>=2.1.0 <https://github.com/nengo/nengo/releases/tag/v2.1.0>`_
-`numpy>=1.10 <https://github.com/numpy/numpy/releases/tag/v1.10.0>`_, and
-`scipy>=0.17.0 <https://github.com/scipy/scipy/releases/tag/v0.17.0>`_.
+`numpy>=1.13 <https://github.com/numpy/numpy/releases/tag/v1.13.0>`_, and
+`scipy>=0.19.0 <https://github.com/scipy/scipy/releases/tag/v0.19.0>`_.
 If you are having difficulty installing SciPy or NumPy, we recommend the
 `Anaconda <https://www.continuum.io/downloads>`_ installer.
 

--- a/docs/nengolib.neurons.init_lif.rst
+++ b/docs/nengolib.neurons.init_lif.rst
@@ -1,0 +1,6 @@
+nengolib\.neurons\.init_lif
+===========================
+
+.. currentmodule:: nengolib.neurons
+
+.. autofunction:: nengolib.neurons.init_lif

--- a/nengolib/__init__.py
+++ b/nengolib/__init__.py
@@ -21,6 +21,14 @@ Learning
 
    learning.RLS
 
+Neurons
+-------
+
+.. autosummary::
+   :toctree:
+
+   neurons.init_lif
+
 Processes
 ---------
 

--- a/nengolib/compat.py
+++ b/nengolib/compat.py
@@ -1,11 +1,5 @@
 import numpy as np
 
-try:
-    from nengo.utils.testing import warns  # noqa: F401
-except ImportError:  # nengo>=2.7.0
-    # https://github.com/nengo/nengo/pull/1381
-    from pytest import warns  # noqa: F401
-
 __all__ = ['get_activities']
 
 

--- a/nengolib/networks/tests/test_linear_network.py
+++ b/nengolib/networks/tests/test_linear_network.py
@@ -5,9 +5,9 @@ import nengo
 
 from nengolib.networks.linear_network import LinearNetwork
 from nengolib import Network, Lowpass
-from nengolib.compat import warns
 from nengolib.signal import s, z, canonical, Identity, shift, nrmse
 from nengolib.synapses import PadeDelay, Bandpass
+from nengolib.testing import warns
 
 
 _mock_solver_calls = 0  # global to keep solver's fingerprint static

--- a/nengolib/networks/tests/test_reservoir.py
+++ b/nengolib/networks/tests/test_reservoir.py
@@ -9,7 +9,7 @@ from nengo.utils.numpy import rmse
 from nengolib.networks.reservoir import Reservoir
 
 from nengolib import Network, Lowpass
-from nengolib.compat import warns
+from nengolib.testing import warns
 
 
 def test_basic(Simulator, seed, plt):

--- a/nengolib/neurons.py
+++ b/nengolib/neurons.py
@@ -5,7 +5,62 @@ from nengo.builder.builder import Builder
 from nengo.builder.neurons import SimNeurons
 from nengo.neurons import NeuronType
 
-__all__ = ['PerfectLIF', 'Unit', 'Tanh']
+__all__ = ['PerfectLIF', 'Unit', 'Tanh', 'init_lif']
+
+
+def _sample_lif_state(sim, ens, x0, rng):
+    """Sample the LIF's voltage/refractory assuming uniform within ISI.
+    """
+    lif = ens.neuron_type
+    params = sim.model.params
+
+    eval_points = x0[None, :]
+    x = np.dot(eval_points, params[ens].encoders.T / ens.radius)[0]
+    a = ens.neuron_type.rates(x, params[ens].gain, params[ens].bias)
+    J = params[ens].gain * x + params[ens].bias
+
+    # fast-forward to a random time within the ISI for any active neurons
+    is_active = a > 0
+    t_isi = np.zeros_like(a)
+    t_isi[is_active] = rng.rand(np.count_nonzero(is_active)) / a[is_active]
+
+    # dt is immediately subtracted from the refractory
+    refractory_time = np.where(
+        is_active & (t_isi < lif.tau_ref),
+        sim.dt + (lif.tau_ref - t_isi), 0)
+    delta_t = (t_isi - lif.tau_ref).clip(0)
+    voltage = -J * np.expm1(-delta_t / lif.tau_rc)
+
+    # fast-forward to the steady-state for any subthreshold neurons
+    subthreshold = ~is_active
+    voltage[subthreshold] = J[subthreshold].clip(0)
+
+    return voltage, refractory_time
+
+
+def init_lif(sim, ens, x0=None, rng=None):
+    """Initialize an ensemble of LIF Neurons to represent ``x0``."""
+    if rng is None:
+        rng = sim.rng
+
+    if x0 is None:
+        x0 = np.zeros(ens.dimensions)
+    else:
+        x0 = np.atleast_1d(x0)
+        if x0.shape != (ens.dimensions,):
+            raise ValueError(
+                "x0 must be an array of length %d" % ens.dimensions)
+
+    if not isinstance(ens.neuron_type, LIF):
+        raise ValueError("ens.neuron_type=%r must be an instance of "
+                         "nengo.LIF" % ens.neuron_type)
+
+    vr = _sample_lif_state(sim, ens, x0, rng)
+
+    # https://github.com/nengo/nengo/issues/1415
+    signal = sim.model.sig[ens.neurons]
+    sim.signals[signal['voltage']], sim.signals[signal['refractory_time']] = vr
+    return vr
 
 
 class PerfectLIF(LIF):

--- a/nengolib/signal/system.py
+++ b/nengolib/signal/system.py
@@ -107,8 +107,9 @@ def sys2tf(sys):
 def _is_ccf(A, B, C, D):
     """Returns true iff (A, B, C, D) is in controllable canonical form."""
     n = len(A)
-    if A.size == 0 and B.size == 0 and C.size == 0:  # scipy 0.17.0
-        return True  # TODO: assumes SISO?
+    if A.size == 0 and B.size == 0 and C.size == 0:  # pragma: no cover
+        # this occurs on scipy 0.17.0 which is unsupported
+        return True
     if not np.allclose(B[0], 1.0):
         return False
     if n <= 1:

--- a/nengolib/signal/tests/test_reduction.py
+++ b/nengolib/signal/tests/test_reduction.py
@@ -5,8 +5,8 @@ from nengo.utils.numpy import rmse
 
 from nengolib.signal.reduction import pole_zero_cancel, modred, balred
 from nengolib import Lowpass, Alpha
-from nengolib.compat import warns
 from nengolib.signal import LinearSystem, balanced_transformation, shift
+from nengolib.testing import warns
 
 
 def test_minreal():

--- a/nengolib/signal/tests/test_system.py
+++ b/nengolib/signal/tests/test_system.py
@@ -12,9 +12,9 @@ from nengolib.signal.system import (
     sys2ss, sys2zpk, sys2tf, canonical, sys_equal, ss_equal, LinearSystem,
     s, z)
 from nengolib import Network, Lowpass, Alpha
-from nengolib.compat import warns
 from nengolib.signal import cont2discrete, shift
 from nengolib.synapses import PadeDelay
+from nengolib.testing import warns
 
 
 def test_sys_conversions():

--- a/nengolib/stats/tests/test_ntmdists.py
+++ b/nengolib/stats/tests/test_ntmdists.py
@@ -7,7 +7,7 @@ from nengo.utils.numpy import norm
 from nengolib.stats.ntmdists import (
     SphericalCoords, Sobol, Rd,
     ScatteredCube, ScatteredHypersphere, cube, sphere, ball)
-from nengolib.compat import warns
+from nengolib.testing import warns
 
 
 @pytest.mark.parametrize("m", [1, 2, 4, 16])

--- a/nengolib/synapses/tests/test_analog.py
+++ b/nengolib/synapses/tests/test_analog.py
@@ -8,8 +8,8 @@ from nengo import Alpha as BaseAlpha
 from nengolib.synapses.analog import (
     Bandpass, Highpass, pade_delay_error, PadeDelay, Lowpass, Alpha, DoubleExp,
     _pade_delay, _passthrough_delay, _proper_delay)
-from nengolib.compat import warns
 from nengolib.signal import sys_equal, s, LinearSystem
+from nengolib.testing import warns
 
 
 def test_nengo_analogs():

--- a/nengolib/temporal.py
+++ b/nengolib/temporal.py
@@ -12,6 +12,7 @@ from nengo.config import SupportDefaultsMixin
 from nengo.params import Default
 from nengo.solvers import Solver, LstsqL2, SolverParam
 from nengo.synapses import SynapseParam, Lowpass
+from nengo.version import version_info
 
 
 class Temporal(Solver, SupportDefaultsMixin):
@@ -123,7 +124,7 @@ class Temporal(Solver, SupportDefaultsMixin):
 
 
 @Builder.register(Temporal)
-def build_temporal_solver(model, solver, conn, rng, transform):
+def build_temporal_solver(model, solver, conn, rng, transform=None):
     # Unpack the relevant variables from the connection.
     assert isinstance(conn.pre_obj, Ensemble)
     ensemble = conn.pre_obj
@@ -174,6 +175,13 @@ def build_temporal_solver(model, solver, conn, rng, transform):
         # ignores the solver and considers only the conn. The only point of
         # passing solver.solver here is to invoke its corresponding builder
         # function in case something custom happens to be registered.
-        return model.build(solver.solver, conn, rng, transform)
+        if version_info >= (2, 8, 1):
+            # https://github.com/nengo/nengo/pull/1481
+            assert transform is None
+            return model.build(solver.solver, conn, rng)
+
+        else:  # pragma: no cover
+            return model.build(solver.solver, conn, rng, transform)
+
     finally:
         neuron_type.rates = save_rates_method

--- a/nengolib/testing.py
+++ b/nengolib/testing.py
@@ -1,0 +1,7 @@
+from nengo.version import version_info
+
+if version_info >= (2, 7, 0):
+    from pytest import warns  # noqa: F401
+else:  # pragma: no cover
+    # https://github.com/nengo/nengo/pull/1381
+    from nengo.utils.testing import warns  # noqa: F401

--- a/nengolib/tests/test_connection.py
+++ b/nengolib/tests/test_connection.py
@@ -6,8 +6,8 @@ import nengo
 from nengo.utils.numpy import rmse
 
 from nengolib import Connection, Network
-from nengolib.compat import warns
 from nengolib.solvers import BiasedSolver
+from nengolib.testing import warns
 
 
 @pytest.mark.parametrize("d", [1, 2])

--- a/nengolib/tests/test_neurons.py
+++ b/nengolib/tests/test_neurons.py
@@ -1,42 +1,143 @@
 import numpy as np
 import pytest
 
+from scipy.stats import kstest
+
 import nengo
 from nengo.utils.numpy import rmse
 
-from nengolib import Network, PerfectLIF
+from nengolib.neurons import init_lif, Tanh, PerfectLIF
+from nengolib import Network
 from nengolib.compat import get_activities
-from nengolib.neurons import init_lif, Tanh
 
 
-@pytest.mark.parametrize("do_initialize", [True, False])
-@pytest.mark.noassertions
-def test_lif_initialize(Simulator, plt, seed, do_initialize):
+@pytest.mark.parametrize("x0", [-1, -0.5, None, 0.5, 1])
+def test_init_lif(Simulator, seed, x0):
+    u = 0 if x0 is None else x0
+    n_neurons = 1000
+    t = 2.0
+    ens_kwargs = dict(
+        n_neurons=n_neurons,
+        dimensions=1,
+        max_rates=nengo.dists.Uniform(10, 100),
+        seed=seed,
+        neuron_type=PerfectLIF(),  # for nengo<2.1.1 tests
+    )
 
     with nengo.Network(seed=seed) as model:
-        stim = nengo.Node(0)
-        x = nengo.Ensemble(2000, 1, max_rates=nengo.dists.Uniform(10, 20))
+        stim = nengo.Node(u)
 
-        nengo.Connection(stim, x, synapse=None)
+        zero = nengo.Ensemble(**ens_kwargs)
+        init = nengo.Ensemble(**ens_kwargs)
 
-        p_v = nengo.Probe(x.neurons, 'voltage', synapse=None)
-        p_x = nengo.Probe(x, synapse=None)
+        nengo.Connection(stim, zero, synapse=None)
+        nengo.Connection(stim, init, synapse=None)
+
+        p_zero_spikes = nengo.Probe(zero.neurons, 'spikes', synapse=None)
+        p_zero_v = nengo.Probe(zero.neurons, 'voltage', synapse=None)
+
+        p_init_spikes = nengo.Probe(init.neurons, 'spikes', synapse=None)
+        p_init_v = nengo.Probe(init.neurons, 'voltage', synapse=None)
 
     with Simulator(model, seed=seed) as sim:
-        if do_initialize:
+        init_lif(sim, init, x0=x0)
+        sim.run(t)
+
+    # same tuning curves
+    a = get_activities(sim.model, zero, [u])
+    assert np.allclose(a, get_activities(sim.model, init, [u]))
+
+    # calculate difference between actual spike counts and ideal
+    count_zero = np.count_nonzero(sim.data[p_zero_spikes], axis=0)
+    count_init = np.count_nonzero(sim.data[p_init_spikes], axis=0)
+    e_zero = count_zero - a * t
+    e_init = count_init - a * t
+
+    # initialized error is close to zero, better than uninitialized,
+    # with std. dev. close to the uninitialized
+    assert np.abs(np.mean(e_init)) < 0.05
+    assert np.abs(np.mean(e_zero)) > 0.1
+    assert np.abs(np.std(e_init) - np.std(e_zero)) < 0.05
+
+    # subthreshold neurons are the same between populations
+    subthresh = np.all(sim.data[p_init_spikes] == 0, axis=0)
+    assert np.allclose(subthresh,
+                       np.all(sim.data[p_zero_spikes] == 0, axis=0))
+    assert 0 < np.count_nonzero(subthresh) < n_neurons
+    is_active = ~subthresh
+
+    # uninitialized always under-counts (unless subthreshold)
+    # the other exception is when a neuron spikes at the very end
+    # since the simulation does not start in its refractory
+    assert np.allclose(e_zero[subthresh], 0)
+    very_end = sim.trange() >= t - init.neuron_type.tau_ref
+    exception = np.any(
+        sim.data[p_zero_spikes][very_end, :] > 0, axis=0)
+    # no more than 10% should be exceptions (heuristic)
+    assert np.count_nonzero(exception) < 0.1 * n_neurons
+    assert np.all(e_zero[is_active & (~exception)] < 0)
+
+    # uninitialized voltages start at 0 (plus first time-step)
+    assert np.all(sim.data[p_zero_v][0, :] < 0.2)
+
+    # initialized sub-threshold voltages remain constant
+    # (steady-state input)
+    assert np.allclose(sim.data[p_init_v][0, subthresh],
+                       sim.data[p_init_v][-1, subthresh])
+
+    def uniformity_test(spikes):
+        # test uniformity of ISIs
+        # returns (r, d, p) where r is the [0, 1) relative
+        # position of the first spike-time within the ISI
+        # d is the KS D-statistic which is the absolute max
+        # distance from the uniform distribution, and p
+        # is the p-value of this statistic
+        t_spike = sim.trange()[
+            [np.where(s > 0)[0][0] for s in spikes[:, is_active].T]]
+        assert t_spike.shape == (np.count_nonzero(is_active),)
+        isi_location = (t_spike - sim.dt) * a[is_active]
+        return (isi_location,) + kstest(isi_location, 'uniform')
+
+    r, d, p = uniformity_test(sim.data[p_init_spikes])
+    assert np.all(r >= 0)
+    assert np.all(r < 1)
+    assert d < 0.1
+
+    r, d, p = uniformity_test(sim.data[p_zero_spikes])
+    assert np.all(r >= 0.7)  # heuristic
+    assert np.all(r < 1)
+    assert d > 0.7
+    assert p < 1e-5
+
+
+def test_init_lif_invalid(Simulator):
+    with nengo.Network() as model:
+        x = nengo.Ensemble(100, 1, neuron_type=nengo.Direct())
+
+    with Simulator(model) as sim:
+        with pytest.raises(ValueError):
             init_lif(sim, x)
-        sim.run(0.3)
 
-    plt.subplot(2, 1, 1)
-    plt.title("Initialized x0" if do_initialize else
-              "Uninitialized (v0=0)")
-    plt.plot(sim.trange(), sim.data[p_x])
-    plt.ylabel("Decoded Spikes")
+    with nengo.Network() as model:
+        x = nengo.Ensemble(100, 2)
 
-    plt.subplot(2, 1, 2)
-    plt.plot(sim.trange(), sim.data[p_v][:, :50])
-    plt.xlabel("Time (s)")
-    plt.ylabel("Voltage")
+    with Simulator(model) as sim:
+        with pytest.raises(ValueError):
+            init_lif(sim, x, x0=0)
+
+
+def test_init_lif_rng(Simulator, seed):
+    with nengo.Network() as model:
+        x = nengo.Ensemble(100, 1)
+
+    with Simulator(model) as sim:
+        v1, r1 = init_lif(sim, x, rng=np.random.RandomState(seed=seed))
+        v2, r2 = init_lif(sim, x, rng=np.random.RandomState(seed=seed))
+
+    assert np.allclose(v1, v2)
+    assert np.allclose(r1, r2)
+    assert v1.shape == (x.n_neurons,)
+    assert r1.shape == (x.n_neurons,)
 
 
 def _test_lif(Simulator, seed, neuron_type, u, dt, n=500, t=2.0):

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ universal = 1
 
 [flake8]
 exclude = _*.py,docs/*.py,build/*.py
-ignore = E226,E741
+ignore = E226,E741,W504
 
 [build_sphinx]
 source-dir = docs

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ version_module = imp.load_source(
 
 deps = [  # https://github.com/nengo/nengo/issues/508
     "nengo>=2.1.0",
-    "numpy>=1.10",
-    "scipy>=0.17.0",
+    "numpy>=1.13",
+    "scipy>=0.19.0",
 ]
 
 download_url = (


### PR DESCRIPTION
Related to https://github.com/nengo/nengo/issues/1415.

This adds a helper function that can be used as follows:

```python
from nengolib.neurons import init_lif

# ... build model containing ensemble x ...

with nengo.Simulator(model) as sim:
    init_lif(sim, x)

    # ... run model ...
```

to initialize the state of the `LIF` ensemble `x` by sampling the steady-state solution given the zero vector as input. This is mathematically equivalent to fast-forwarding in time (to after the mixing time of the stochastic process, and after any subthreshold neurons have stabilized at `v = J`), which solves the problem of the start of the simulation having some initial transient / degenerate state.

It also takes into account the tuning curves (e.g., for thresholding ensembles), and supports initializing at values other than 0, including higher-dimensions.

TODO:
 - [x] Document this with sphinx example
 - [x] Document this in CHANGES.rst
 - [x] More comprehensive testing with assertions