### PR TITLE
Legendre delay network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
     - env:
         PYTHON="2.7"
         NENGO=""
-        PIP_DEPS="nengo==2.1.0 pytest==3.2"
-    - env:
-        PYTHON="2.7"
-        NENGO=""
         PIP_DEPS="nengo==2.2.0 pytest==3.2"
     - env:
         PYTHON="2.7"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,14 @@ We now require ``numpy>=1.13.0``, ``scipy>=0.19.0``, and ``nengo>=2.2.0``.
   for initializing the neural state of a ``LIF`` ensemble, from within
   a simulator block, to represent ``0`` uniformly at the start.
   (`#156 <https://github.com/arvoelke/nengolib/pull/156>`_)
+- Added ``nengolib.synapses.LegendreDelay`` as an alternative to
+  ``nengolib.synapses.PadeDelay`` -- it has an equivalent transfer function
+  but a state-space realization corresponding to the shifted
+  Legendre basis.
+  The network ``nengolib.networks.RollingWindow`` support ``legendre=True``
+  to make this system the default realization.
+  (`#161 <https://github.com/arvoelke/nengolib/pull/161>`_)
+
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Release History
 0.4.3 (unreleased)
 ==================
 
-Tested against Nengo versions 2.1.0-2.8.0.
-We now require ``numpy>=1.13.0`` and ``scipy>=0.19.0``.
+Tested against Nengo versions 2.2.0-2.8.0.
+We now require ``numpy>=1.13.0``, ``scipy>=0.19.0``, and ``nengo>=2.2.0``.
 
 **Added**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ Installation
 
 `Nengolib <https://github.com/arvoelke/nengolib/>`_
 is tested against Python 2.7, 3.4, 3.5, and 3.6, and `Nengo`_
-2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2,7.0, and 2.8.0.
+2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2,7.0, and 2.8.0.
 We recommend ``nengo==2.8.0`` for complete access to features.
 The `Nengo GUI <https://github.com/nengo/nengo_gui>`_ is not officially
 supported.

--- a/docs/nengolib.PerfectLIF.rst
+++ b/docs/nengolib.PerfectLIF.rst
@@ -1,6 +1,0 @@
-nengolib\.PerfectLIF
-====================
-
-.. currentmodule:: nengolib
-
-.. autoclass:: nengolib.PerfectLIF

--- a/docs/nengolib.synapses.LegendreDelay.rst
+++ b/docs/nengolib.synapses.LegendreDelay.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: nengolib.synapses
+
+nengolib\.synapses\.LegendreDelay
+=================================
+
+.. autofunction:: nengolib.synapses.LegendreDelay
+

--- a/docs/notebooks/examples/_decoding_derivative.ipynb
+++ b/docs/notebooks/examples/_decoding_derivative.ipynb
@@ -57,7 +57,7 @@
       "\n",
       "def make_model(synapses, encoders, decoders, n_neurons, tau_derivative,\n",
       "               seed, stim_seed, dt, T, stim_cutoff_freq=15, stim_rms=0.5,\n",
-      "               neuron_type=nengolib.PerfectLIF()):\n",
+      "               neuron_type=nengo.LIF()):\n",
       "\n",
       "    with nengolib.Network(seed=seed) as model:\n",
       "\n",

--- a/docs/notebooks/research/discrete_comparison.ipynb
+++ b/docs/notebooks/research/discrete_comparison.ipynb
@@ -36,7 +36,7 @@
    "outputs": [],
    "source": [
     "def go(sys=nengolib.synapses.Bandpass(20, 5), T=1.0, dt=0.001, n_neurons=200,\n",
-    "       synapse=0.02, seed=0, discretized=True, neuron_type=nengolib.PerfectLIF()):\n",
+    "       synapse=0.02, seed=0, discretized=True, neuron_type=nengo.LIF()):\n",
     "\n",
     "    with nengolib.Network(seed=seed) as model:\n",
     "        stim = nengo.Node(output=nengo.processes.WhiteSignal(T, high=50, rms=0.1, y0=0))\n",

--- a/nengolib/__init__.py
+++ b/nengolib/__init__.py
@@ -52,7 +52,6 @@ from .connection import Connection
 from .learning import RLS
 from .monkeypatch import patch, unpatch
 from .network import Network
-from .neurons import PerfectLIF
 from .solvers import Temporal
 
 from . import compat

--- a/nengolib/monkeypatch.py
+++ b/nengolib/monkeypatch.py
@@ -15,8 +15,6 @@ def patch(network=True, connection=True):
         nengo.Network = Network
     if connection:
         nengo.Connection = Connection
-    # note: nengolib.PerfectLIF is not substituted for nengo.LIF, but it will
-    # become the default due to the Network substitution
 
 
 def unpatch():

--- a/nengolib/network.py
+++ b/nengolib/network.py
@@ -1,7 +1,6 @@
 from nengo import Network as BaseNetwork
 from nengo import Ensemble
 
-from nengolib.neurons import PerfectLIF
 from nengolib.stats.ntmdists import ball, sphere
 
 _all__ = ['Network']
@@ -16,8 +15,6 @@ class Network(BaseNetwork):
 
     * ``eval_points=``:attr:`.ball`
 
-    * ``neuron_type=``:class:`.PerfectLIF()`
-
     Parameters
     ----------
     *args : ``list``, optional
@@ -31,7 +28,6 @@ class Network(BaseNetwork):
     :class:`nengo.Ensemble`
     :attr:`.ball`
     :attr:`.sphere`
-    :class:`.PerfectLIF`
 
     Examples
     --------
@@ -43,4 +39,4 @@ class Network(BaseNetwork):
         self.config[Ensemble].update({
             'encoders': sphere,
             'eval_points': ball,
-            'neuron_type': PerfectLIF()})
+        })

--- a/nengolib/networks/rolling_window.py
+++ b/nengolib/networks/rolling_window.py
@@ -87,6 +87,11 @@ class RollingWindow(LinearNetwork):
     solver : :class:`nengo.solvers.Solver`, optional
         Solver to use for connections from the state ensemble.
         Defaults to :class:`nengo.solvers.LstsqL2` (with ``reg=1e-3``).
+    legendre : ``boolean``, optional
+        Changes the canonical realization to that of :func:`.LegendreDelay`,
+        the shifted Legendre polynomials,
+        :math:`P_i(2 \\theta' \\theta^{-1} - 1)`.
+        Defaults to ``False``.
     **kwargs : ``dictionary``, optional
         Additional keyword arguments passed to :class:`.LinearNetwork`.
         Those that fall under the heading of ``**ens_kwargs`` will be
@@ -138,8 +143,7 @@ class RollingWindow(LinearNetwork):
     >>>     process = nengo.processes.WhiteSignal(100., high=25, y0=0)
     >>>     stim = nengo.Node(output=process)
     >>>     rw = RollingWindow(theta=.05, n_neurons=2500, process=process,
-    >>>                        neuron_type=nengo.LIFRate(),
-    >>>                        realizer=Hankel())
+    >>>                        neuron_type=nengo.LIFRate(), legendre=True)
     >>>     nengo.Connection(stim, rw.input, synapse=None)
     >>>     p_stim = nengo.Probe(stim)
     >>>     p_delay = nengo.Probe(rw.output)
@@ -161,8 +165,8 @@ class RollingWindow(LinearNetwork):
     >>> plt.show()
 
     Visualizing the canonical basis functions. The state of the
-    :func:`PadeDelay` system takes a linear combination of these to
-    represent the current window of history:
+    :func:`LegendreDelay` system takes a linear combination of these
+    shifted Legendre polynomials to represent the current window of history:
 
     >>> plt.title("canonical_basis()")
     >>> plt.plot(t_default, rw.canonical_basis())

--- a/nengolib/networks/tests/test_linear_network.py
+++ b/nengolib/networks/tests/test_linear_network.py
@@ -15,9 +15,13 @@ _mock_solver_calls = 0  # global to keep solver's fingerprint static
 
 class MockSolver(nengo.solvers.LstsqL2):
 
-    def __call__(self, A, Y, rng=None, E=None):
+    def __call__(self, A, Y, __hack__=None, **kwargs):
+        assert __hack__ is None
+        # __hack__ is necessary prior to nengo PR #1359 (<2.6.1)
+        # and following nengo PR #1507 (>2.8.0)
+
         globals()['_mock_solver_calls'] += 1
-        return super(MockSolver, self).__call__(A, Y, rng=rng, E=E)
+        return super(MockSolver, self).__call__(A, Y, **kwargs)
 
 
 @pytest.mark.parametrize("neuron_type,atol,atol_x", [

--- a/nengolib/neurons.py
+++ b/nengolib/neurons.py
@@ -5,7 +5,7 @@ from nengo.builder.builder import Builder
 from nengo.builder.neurons import SimNeurons
 from nengo.neurons import NeuronType
 
-__all__ = ['PerfectLIF', 'Unit', 'Tanh', 'init_lif']
+__all__ = ['Unit', 'Tanh', 'init_lif']
 
 
 def _sample_lif_state(sim, ens, x0, rng):
@@ -115,63 +115,6 @@ def init_lif(sim, ens, x0=None, rng=None):
     signal = sim.model.sig[ens.neurons]
     sim.signals[signal['voltage']], sim.signals[signal['refractory_time']] = vr
     return vr
-
-
-class PerfectLIF(LIF):
-    """Spiking version of the leaky integrate-and-fire (LIF) neuron model.
-
-    This model spikes with the same rate as :class:`nengo.LIFRate` assuming
-    zero-order hold (ZOH). [#]_
-
-    Parameters
-    ----------
-    *args : ``list``, optional
-        Additional arguments passed to :class:`nengo.LIF`.
-    **kwargs : ``dictionary``, optional
-        Additional keyword arguments passed to :class:`nengo.LIF`.
-
-    See Also
-    --------
-    :class:`nengo.LIF`
-    :class:`nengo.neurons.NeuronType`
-
-    Notes
-    -----
-    This is Nengo's default neuron model since ``nengo>=2.1.1``.
-
-    References
-    ----------
-    .. [#] https://github.com/nengo/nengo/pull/975
-    """
-
-    def step_math(self, dt, J, spiked, voltage, refractory_time):
-        # reduce all refractory times by dt
-        refractory_time -= dt
-
-        # compute effective dt for each neuron, based on remaining time.
-        # note that refractory times that have completed midway into this
-        # timestep will be given a partial timestep, and moreover these will
-        # be subtracted to zero at the next timestep (or reset by a spike)
-        delta_t = (dt - refractory_time).clip(0, dt)
-
-        # update voltage using discretized lowpass filter
-        # since v(t) = v(0) + (J - v(0))*(1 - exp(-t/tau)) assuming
-        # J is constant over the interval [t, t + dt)
-        voltage -= (J - voltage) * np.expm1(-delta_t / self.tau_rc)
-
-        # determine which neurons spiked (set them to 1/dt, else 0)
-        spiked_mask = voltage > 1
-        spiked[:] = spiked_mask / dt
-
-        # set v(0) = 1 and solve for t to compute the spike time
-        t_spike = dt + self.tau_rc * np.log1p(
-            -(voltage[spiked_mask] - 1) / (J[spiked_mask] - 1))
-
-        # set spiked voltages to zero, refractory times to tau_ref, and
-        # rectify negative voltages to a floor of min_voltage
-        voltage[voltage < self.min_voltage] = self.min_voltage
-        voltage[spiked_mask] = 0
-        refractory_time[spiked_mask] = self.tau_ref + t_spike
 
 
 class Unit(NeuronType):

--- a/nengolib/solvers.py
+++ b/nengolib/solvers.py
@@ -30,7 +30,11 @@ class BiasedSolver(Solver):
             super(BiasedSolver, self).__init__()
             self.weights = solver.weights
 
-    def __call__(self, A, Y, rng=None, E=None):
+    def __call__(self, A, Y, __hack__=None, **kwargs):
+        assert __hack__ is None
+        # __hack__ is necessary prior to nengo PR #1359 (<2.6.1)
+        # and following nengo PR #1507 (>2.8.0)
+
         if self.bias is not None:
             # this is okay if due to multiple builds of the same network (#99)
             warnings.warn("%s called twice; ensure not being shared between "
@@ -40,7 +44,7 @@ class BiasedSolver(Solver):
         AB = np.empty((A.shape[0], A.shape[1] + 1))
         AB[:, :-1] = A
         AB[:, -1] = scale
-        XB, solver_info = self.solver.__call__(AB, Y, rng=rng, E=E)
+        XB, solver_info = self.solver.__call__(AB, Y, **kwargs)
         solver_info['bias'] = self.bias = XB[-1, :] * scale
         return XB[:-1, :], solver_info
 

--- a/nengolib/synapses/__init__.py
+++ b/nengolib/synapses/__init__.py
@@ -16,6 +16,7 @@ Analog
    Bandpass
    Highpass
    PadeDelay
+   LegendreDelay
 
 Digital
 -------

--- a/nengolib/synapses/analog.py
+++ b/nengolib/synapses/analog.py
@@ -409,11 +409,12 @@ def PadeDelay(theta, order, p=None):
 
     Returns
     -------
-    :class:`.LinearSystem`
+    sys : :class:`.LinearSystem`
         Finite-order approximation of a pure time-delay.
 
     See Also
     --------
+    :func:`.LegendreDelay`
     :func:`.pade_delay_error`
     :class:`.RollingWindow`
     :func:`.DiscreteDelay`
@@ -471,7 +472,59 @@ def PadeDelay(theta, order, p=None):
 
 
 def LegendreDelay(theta, order):
-    """PadeDelay(theta, order) realizing the shifted Legendre basis."""
+    """PadeDelay(theta, order) realizing the shifted Legendre basis.
+
+    The transfer function is equivalent to :func:`.PadeDelay`, but its
+    canonical state-space realization represents the window of history
+    by the shifted Legendre polnomials:
+
+    .. math::
+
+       P_i(2 \\theta' \\theta^{-1} - 1)
+
+    where ``i`` is the zero-based index into the state-vector.
+
+    Parameters
+    ----------
+    theta : ``float``
+        Length of time-delay in seconds.
+    order : ``integer``
+        Order of approximation in the denominator
+        (dimensionality of resulting system).
+
+    Returns
+    -------
+    sys : :class:`.LinearSystem`
+        Finite-order approximation of a pure time-delay.
+
+    See Also
+    --------
+    :func:`.PadeDelay`
+    :func:`.pade_delay_error`
+    :class:`.RollingWindow`
+
+    Examples
+    --------
+    >>> from nengolib.synapses import LegendreDelay
+
+    Delay 15 Hz band-limited white noise by 100 ms using various orders of
+    approximations:
+
+    >>> from nengolib.signal import z
+    >>> from nengo.processes import WhiteSignal
+    >>> import matplotlib.pyplot as plt
+    >>> process = WhiteSignal(10., high=15, y0=0)
+    >>> u = process.run_steps(500)
+    >>> t = process.ntrange(len(u))
+    >>> plt.plot(t, (z**-100).filt(u), linestyle='--', lw=4, label="Ideal")
+    >>> for order in list(range(4, 9)):
+    >>>     sys = LegendreDelay(.1, order=order)
+    >>>     assert len(sys) == order
+    >>>     plt.plot(t, sys.filt(u), label="order=%s" % order)
+    >>> plt.xlabel("Time (s)")
+    >>> plt.legend()
+    >>> plt.show()
+    """
 
     q = _check_order(order)
 

--- a/nengolib/synapses/tests/test_analog.py
+++ b/nengolib/synapses/tests/test_analog.py
@@ -6,7 +6,8 @@ from nengo import Lowpass as BaseLowpass
 from nengo import Alpha as BaseAlpha
 
 from nengolib.synapses.analog import (
-    Bandpass, Highpass, pade_delay_error, PadeDelay, Lowpass, Alpha, DoubleExp,
+    Bandpass, Highpass, pade_delay_error,
+    PadeDelay, LegendreDelay, Lowpass, Alpha, DoubleExp,
     _pade_delay, _passthrough_delay, _proper_delay)
 from nengolib.signal import sys_equal, s, LinearSystem
 from nengolib.testing import warns
@@ -112,8 +113,9 @@ def test_pade_error(plt):
         assert np.all(np.diff(error) > -1e-13), order
 
 
-@pytest.mark.parametrize("p", [1, 2, 3])
-def test_pade_versions(p):
+@pytest.mark.parametrize("p", range(1, 9))
+@pytest.mark.parametrize("c", [0.5, 1, 3])
+def test_pade_versions(p, c):
     c = 1
     # make sure all of the delay methods do the same thing
     assert _pade_delay(p, p+1, c) == _proper_delay(p+1, c)
@@ -123,6 +125,8 @@ def test_pade_versions(p):
     assert _proper_delay(p+1, c) == PadeDelay(c, order=p+1)
     assert _passthrough_delay(p, c) == PadeDelay(c, order=p, p=p)
     assert _pade_delay(p, p+2, c) == PadeDelay(c, order=p+2, p=p)
+
+    assert LegendreDelay(c, order=p+1) == PadeDelay(c, order=p+1)
 
 
 def test_delay_invalid():
@@ -140,6 +144,12 @@ def test_delay_invalid():
 
     with pytest.raises(ValueError):
         PadeDelay(1, order=2, p=1.5)
+
+    with pytest.raises(ValueError):
+        LegendreDelay(1, order=3.5)
+
+    with pytest.raises(ValueError):
+        LegendreDelay(1, order=-1)
 
     with warns(UserWarning):
         PadeDelay(1, order=10, p=8)

--- a/nengolib/synapses/tests/test_analog.py
+++ b/nengolib/synapses/tests/test_analog.py
@@ -129,7 +129,15 @@ def test_pade_versions(p, c):
     assert LegendreDelay(c, order=p+1) == PadeDelay(c, order=p+1)
 
 
+@pytest.mark.parametrize("theta", [0.1, 1, 3])
+def test_1d_legendre_delay(theta):
+    assert LegendreDelay(theta, order=1) == Lowpass(theta)
+
+
 def test_delay_invalid():
+    with warns(UserWarning):
+        PadeDelay(1, order=10, p=8)
+
     with pytest.raises(ValueError):
         PadeDelay(1, order=0)
 
@@ -150,9 +158,6 @@ def test_delay_invalid():
 
     with pytest.raises(ValueError):
         LegendreDelay(1, order=-1)
-
-    with warns(UserWarning):
-        PadeDelay(1, order=10, p=8)
 
 
 def test_equivalent_defs():

--- a/nengolib/temporal.py
+++ b/nengolib/temporal.py
@@ -117,10 +117,14 @@ class Temporal(Solver, SupportDefaultsMixin):
         self.solver = solver
         Solver.__init__(self, weights=self.solver.weights)
 
-    def __call__(self, A, Y, rng=None, E=None):  # nengo issue #1358
+    def __call__(self, A, Y, __hack__=None, **kwargs):
+        assert __hack__ is None
+        # __hack__ is necessary prior to nengo PR #1359 (<2.6.1)
+        # and following nengo PR #1507 (>2.8.0)
+
         # Note: mul_encoders is never called directly on self.
         # It is invoked on the sub-solver through the following call.
-        return self.solver.__call__(A, Y, rng=rng, E=E)
+        return self.solver.__call__(A, Y, **kwargs)
 
 
 @Builder.register(Temporal)

--- a/nengolib/tests/test_monkeypatch.py
+++ b/nengolib/tests/test_monkeypatch.py
@@ -3,7 +3,6 @@ from nengo import Connection as NengoConnection, Network as NengoNetwork
 
 from nengolib.monkeypatch import patch, unpatch
 from nengolib import Network, Connection
-from nengolib.neurons import PerfectLIF
 from nengolib.stats import ScatteredHypersphere
 
 
@@ -71,6 +70,5 @@ def test_model():
     for ens in model.all_ensembles:
         assert isinstance(ens.eval_points, ScatteredHypersphere)
         assert isinstance(ens.encoders, ScatteredHypersphere)
-        assert isinstance(ens.neuron_type, PerfectLIF)
 
     reload(nengo)

--- a/nengolib/tests/test_network.py
+++ b/nengolib/tests/test_network.py
@@ -1,7 +1,7 @@
 import nengo
 from nengo import Network as BaseNetwork
 
-from nengolib import Network, PerfectLIF
+from nengolib import Network
 from nengolib.stats import ScatteredHypersphere
 
 
@@ -10,13 +10,11 @@ def test_network():
         x = nengo.Ensemble(100, 1)
         assert isinstance(x.eval_points, ScatteredHypersphere)
         assert isinstance(x.encoders, ScatteredHypersphere)
-        assert isinstance(x.neuron_type, PerfectLIF)
 
     with BaseNetwork():
         x = nengo.Ensemble(100, 1)
         assert not isinstance(x.eval_points, ScatteredHypersphere)
         assert not isinstance(x.encoders, ScatteredHypersphere)
-        assert not isinstance(x.neuron_type, PerfectLIF)
 
 
 def test_ensemble_array():
@@ -25,4 +23,3 @@ def test_ensemble_array():
         for ens in ea.ea_ensembles:
             assert isinstance(ens.eval_points, ScatteredHypersphere)
             assert isinstance(ens.encoders, ScatteredHypersphere)
-            assert isinstance(ens.neuron_type, PerfectLIF)

--- a/nengolib/tests/test_neurons.py
+++ b/nengolib/tests/test_neurons.py
@@ -6,7 +6,7 @@ from scipy.stats import kstest
 import nengo
 from nengo.utils.numpy import rmse
 
-from nengolib.neurons import init_lif, Tanh, PerfectLIF
+from nengolib.neurons import init_lif, Tanh
 from nengolib import Network
 from nengolib.compat import get_activities
 
@@ -21,7 +21,6 @@ def test_init_lif(Simulator, seed, x0):
         dimensions=1,
         max_rates=nengo.dists.Uniform(10, 100),
         seed=seed,
-        neuron_type=PerfectLIF(),  # for nengo<2.1.1 tests
     )
 
     with nengo.Network(seed=seed) as model:
@@ -159,7 +158,7 @@ def _test_lif(Simulator, seed, neuron_type, u, dt, n=500, t=2.0):
 def test_perfect_lif_performance(Simulator, seed):
     for dt in np.linspace(0.0005, 0.002, 3):
         for u in np.linspace(-1, 1, 6):
-            error_perfect_lif = _test_lif(Simulator, seed, PerfectLIF(), u, dt)
+            error_perfect_lif = _test_lif(Simulator, seed, nengo.LIF(), u, dt)
             assert error_perfect_lif < 1
             seed += 1
 
@@ -171,7 +170,7 @@ def test_perfect_lif_invariance(Simulator, seed):
     errors = []
     for dt in (0.0001, 0.0005, 0.001, 0.002):
         assert np.allclose(int(t / dt), t / dt)
-        error = _test_lif(Simulator, seed, PerfectLIF(), 0, dt, t=t)
+        error = _test_lif(Simulator, seed, nengo.LIF(), 0, dt, t=t)
         errors.append(error)
     assert np.allclose(errors, errors[0])
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ version_module = imp.load_source(
     'version', os.path.join(root, name, 'version.py'))
 
 deps = [  # https://github.com/nengo/nengo/issues/508
-    "nengo>=2.1.0",
+    "nengo>=2.2.0",
     "numpy>=1.13",
     "scipy>=0.19.0",
 ]


### PR DESCRIPTION
`LegendreDelay` version of `PadeDelay` and `legendre=True` flag to `RollingWindow` (defaults to `False`). Also sets the stage for #160.

Misc:
 - Dropped support for nengo<=2.1.1

TODO:
 - [x] Include in documentation and build
 - [x] Include in CHANGES