### PR TITLE
Replace deprecated imports.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Release History
 0.5.2 (unreleased)
 ==================
 
+**Fixed**
+
+- Solved an issue where scipy.misc imports were relocated.
+  (`#182 <https://github.com/arvoelke/nengolib/pull/182>`_)
+
 0.5.1 (April 17, 2019)
 ======================
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 Aaron Voelker <arvoelke@gmail.com>
+Ivana Kajić <ivana.kajic@gmail.com> (PR #182)

--- a/nengolib/synapses/analog.py
+++ b/nengolib/synapses/analog.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 import warnings
-from scipy.misc import pade, factorial
+from scipy.interpolate import pade
+from scipy.special import factorial
 
 from nengo.utils.compat import is_integer
 
@@ -418,7 +419,7 @@ def PadeDelay(theta, order, p=None):
     :func:`.pade_delay_error`
     :class:`.RollingWindow`
     :func:`.DiscreteDelay`
-    :func:`scipy.misc.pade`
+    :func:`scipy.interpolate.pade`
 
     Notes
     -----


### PR DESCRIPTION
Replaced deprecated usage of `pade` and `factorial` in `scipy.misc` with their new locations.

More details on package relocations: https://docs.scipy.org/doc/scipy-1.1.0/reference/misc.html